### PR TITLE
Get SID of the current user

### DIFF
--- a/SFTA.ps1
+++ b/SFTA.ps1
@@ -42,6 +42,7 @@
     
 #>
 
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
 function Get-FTA {
   [CmdletBinding()]
@@ -471,7 +472,7 @@ function Set-FTA {
 
   function local:Get-UserSid {
     [OutputType([string])]
-    $userSid = ((New-Object System.Security.Principal.NTAccount([Environment]::UserName)).Translate([System.Security.Principal.SecurityIdentifier]).value).ToLower()
+    $userSid = ([System.DirectoryServices.AccountManagement.UserPrincipal]::Current).SID.Value.ToLower()
     Write-Output $userSid
   }
 


### PR DESCRIPTION
The current method of retrieving the current user Security Identifier doesn't work for domain-joined computers when there are local users accounts and domain user accounts with the same name. The SID of the local account is always returned.

This PR uses `System.DirectoryServices.AccountManagement`.